### PR TITLE
Add dataset-go versions match check (fail on version mismatch)

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -41,6 +41,16 @@ jobs:
           submodules: 'true'
           token: ${{ github.token }}
 
+      # Verify that version defined in the builder file and in dataset-go/pkg/version/version.go matches
+      - name: Verify dataset-go Versions Match
+        run: |
+          DATASET_GO_VERSION=$(cat dataset-go/pkg/version/version.go | grep Version | grep '= "' | awk '{print $3}' | tr -d '"')
+
+          echo "Verifying dataset-go version \"${DATASET_GO_VERSION}\" is present in otelcol-builder*.yaml files."
+
+          cat otelcol-builder.yaml | grep "github.com/scalyr/dataset-go" | grep "v${DATASET_GO_VERSION}"
+          cat otelcol-builder.datasetexporter-latest.yaml  | grep "github.com/scalyr/dataset-go" | grep "v${DATASET_GO_VERSION}"
+
       - name: Log in to the Container registry - GitHub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
This pull request updates build and release docker image workflow and adds a check which fails the build in case dataset-go version defined inside the `dataset-go` library (`dataset-go/pkg/version/version.go`) doesn't match version defined in the otelcol builder files.

We missed this change multiple times in the past, so it makes sense to add automated check to catch small issues like that earlier.