### PR TITLE
Also run all the workflows on merge queue requests

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     branches:
       - main

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     branches:
       - main

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     branches:
       - main

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  merge_group:
   pull_request:
     branches:
       - main

--- a/.github/workflows/secrets-scanner.yaml
+++ b/.github/workflows/secrets-scanner.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This pull request updates all the workflows so they are also triggered for merge queue requests (https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) so we can utilize merge queues.