### PR TITLE
Fail fast when env DATASET_API_KEY is missing

### DIFF
--- a/scripts/e2e/test.sh
+++ b/scripts/e2e/test.sh
@@ -82,9 +82,14 @@ if [ "x${DATASET_URL}" == "x" ]; then
   export DATASET_URL="http://dataset-dummy-server-e2e:8000";
   export DATASET_API_KEY="dummy";
 fi;
-log "DATASET_URL: ${DATASET_URL}";
-log "DATASET_API_KEY: XXXXX${DATASET_API_KEY: -4}";
-log "TEST_RUN_SERVERHOST: ${TEST_RUN_SERVERHOST}"
+log "DATASET_URL: '${DATASET_URL}'";
+log "DATASET_API_KEY: '${DATASET_API_KEY: -4}' (last 4 characters)";
+log "TEST_RUN_SERVERHOST: '${TEST_RUN_SERVERHOST}'"
+
+if [ "x${DATASET_API_KEY}" == "x" ]; then
+  log "Environmental variable DATASET_API_KEY is not set!";
+  exit 1;
+fi;
 
 # stop previous runs
 docker compose -f docker-compose.yaml down


### PR DESCRIPTION
When I check the current output of the failed job - https://github.com/scalyr/opentelemetry-exporter-dataset/actions/runs/6608806398/job/18843984634?pr=31#step:9:19

```
18 2023-11-20T09:57:05+00:00 DATASET_URL: https://app.scalyr.com/
19 2023-11-20T09:57:05+00:00 DATASET_API_KEY: XXXXX
...
50 Error: invalid configuration: exporters::dataset/logs: api_key is required
51 2023/11/20 09:57:08 collector server run finished with error: invalid configuration: exporters::dataset/logs: api_key is required
```

It's little bit confusing, since the real error is hidden in the middle. So lets fail fast when the environmental variable is not set.