### PR TITLE
Remove Go 1.20 and add 1.22 in CI/CD

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        go: ['1.20', '1.21']
+        go: ['1.21', '1.22']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
CI/CD starts to fail - https://github.com/scalyr/opentelemetry-exporter-dataset/actions/runs/10465066687/job/28979685558

It could be caused by fact, that is that for more than 6 months - https://endoflife.date/go